### PR TITLE
Drop long data fields from main page

### DIFF
--- a/src/components/useMentors.js
+++ b/src/components/useMentors.js
@@ -47,9 +47,9 @@ export default function useMentors(allMentors, pageSize = 48) {
         ' ' +
         mentor.workplace +
         ' ' +
-        mentor.description +
+        (mentor.description || '') +
         ' ' +
-        mentor.about +
+        (mentor.about || '') +
         ' ' +
         mentor.competencies
       ).toLowerCase()

--- a/src/pages/api/internal/mentors.js
+++ b/src/pages/api/internal/mentors.js
@@ -79,6 +79,10 @@ export async function getMentors(params) {
     })
   }
 
+  if (params.drop_long_fields) {
+    result = result.map( ({about, description, ...m}) => m)
+  }
+
   if (params.id) {
     const id = parseInt(params.id, 10)
     result = result.filter((m) => m.id === id)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,7 +20,7 @@ import VisibilitySensor from 'react-visibility-sensor'
 import { initFaro } from '../lib/faro'
 
 export async function getServerSideProps(context) {
-  const pageMentors = await getAllMentors({ onlyVisible: true })
+  const pageMentors = await getAllMentors({ onlyVisible: true, drop_long_fields: true })
 
   return {
     props: {

--- a/src/pages/ontico.js
+++ b/src/pages/ontico.js
@@ -17,7 +17,7 @@ import { useEffect } from 'react'
 import { initFaro } from '../lib/faro'
 
 export async function getServerSideProps(context) {
-  const allMentors = await getAllMentors({ onlyVisible: true })
+  const allMentors = await getAllMentors({ onlyVisible: true, drop_long_fields: true })
 
   const pageMentors = allMentors.filter((mentor) => mentor.tags.includes('Сообщество Онтико'))
 

--- a/src/server/airtable-mentors.js
+++ b/src/server/airtable-mentors.js
@@ -62,7 +62,6 @@ async function getMentorsInternal(formula = '') {
       experience: item.fields['Experience'],
       price: item.fields['Price'],
       menteeCount: item.fields['Done Sessions Count'],
-      photo: item.fields['Image_Attachment'][0],
       photo_url: item.fields['Image'],
       tags: tags,
       sortOrder: item.fields['SortOrder'] || 10000,

--- a/src/server/mentors-data.js
+++ b/src/server/mentors-data.js
@@ -54,6 +54,7 @@ async function fakeApiCall(params) {
     id: params?.id,
     slug: params?.slug,
     rec: params?.rec,
+    drop_long_fields: params?.drop_long_fields,
   })
 
   if (res && (params.id || params.slug || params.rec)) {


### PR DESCRIPTION
Remove unused `photo` field and two large text fields (`description` and `about`) from the main page to reduce its size.
Tradeoff here is that the text search will no longer work through those fields, but I _believe_ `competencies` field and other filters would be enough. If you read this commit and really miss those features - let me know.