### PR TITLE
add ad block slot to mentors list on the main page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -100,7 +100,7 @@ const nextConfig = {
               "img-src 'self' https: data:; " +
               "font-src 'self' data: https://fonts.gstatic.com https://at.alicdn.com https://yastatic.net; " +
               "connect-src 'self' https://api.mixpanel.com https://decide.mixpanel.com https://a.getmentor.dev https://us.i.posthog.com https://eu.i.posthog.com https://eu.posthog.com https://getmentor.dev https://xn--c1aea1aggold.xn--p1ai https://ru.getmentor.dev https://mc.yandex.ru https://mc.yandex.com https://www.google-analytics.com https://region1.analytics.google.com https://stats.g.doubleclick.net https://google.com https://www.google.com https://faro-collector-prod-eu-west-3.grafana.net wss://mc.yandex.com wss://mc.yandex.ru https://yandex.ru; " +
-              'frame-src https://www.google.com https://calendly.com https://koalendar.com https://calendlab.ru https://docs.google.com; ' +
+              'frame-src https://www.google.com https://calendly.com https://koalendar.com https://calendlab.ru https://docs.google.com https://yastatic.net; ' +
               "object-src 'none'; " +
               "base-uri 'self'; " +
               "form-action 'self'; " +

--- a/src/__tests__/components/MentorsList.test.tsx
+++ b/src/__tests__/components/MentorsList.test.tsx
@@ -45,6 +45,7 @@ jest.mock('next/link', () => ({
 jest.mock('@/lib/azure-image-loader', () => ({
   imageLoader: ({ src, quality }: { src: string; quality: string }) =>
     `https://storage.example.com/${src}-${quality}.jpg`,
+  updatedAtToVersion: () => 'v1',
 }))
 
 const mockMentors: MentorListItem[] = [
@@ -166,5 +167,72 @@ describe('MentorsList', () => {
     render(<MentorsList mentors={[]} hasMore={false} onClickMore={() => {}} />)
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  describe('ad block placement', () => {
+    const makeMentors = (count: number): MentorListItem[] =>
+      Array.from({ length: count }, (_, i) => ({
+        ...mockMentors[0],
+        id: i + 1,
+        mentorId: `rec${i + 1}`,
+        slug: `mentor-${i + 1}`,
+        name: `Mentor ${i + 1}`,
+      }))
+
+    it('does not render ad when showAd is not set', () => {
+      render(<MentorsList mentors={makeMentors(10)} hasMore={false} onClickMore={() => {}} />)
+      expect(screen.queryByTestId('mentors-list-ad')).not.toBeInTheDocument()
+    })
+
+    it('hides ad when fewer than 4 mentors', () => {
+      render(<MentorsList mentors={makeMentors(3)} hasMore={false} onClickMore={() => {}} showAd />)
+      expect(screen.queryByTestId('mentors-list-ad')).not.toBeInTheDocument()
+    })
+
+    it('places ad at position 4 when between 4 and 8 mentors', () => {
+      const { container } = render(
+        <MentorsList mentors={makeMentors(8)} hasMore={false} onClickMore={() => {}} showAd />
+      )
+
+      const grid = container.querySelector('.grid')
+      expect(grid).not.toBeNull()
+
+      const children = Array.from(grid?.children ?? [])
+      expect(children).toHaveLength(9)
+      expect(children[3]).toHaveAttribute('data-testid', 'mentors-list-ad')
+    })
+
+    it('places ad at position 4 with exactly 4 mentors', () => {
+      const { container } = render(
+        <MentorsList mentors={makeMentors(4)} hasMore={false} onClickMore={() => {}} showAd />
+      )
+
+      const grid = container.querySelector('.grid')
+      const children = Array.from(grid?.children ?? [])
+      expect(children).toHaveLength(5)
+      expect(children[3]).toHaveAttribute('data-testid', 'mentors-list-ad')
+    })
+
+    it('places ad at position 8 with 9 or more mentors', () => {
+      const { container } = render(
+        <MentorsList mentors={makeMentors(20)} hasMore={false} onClickMore={() => {}} showAd />
+      )
+
+      const grid = container.querySelector('.grid')
+      const children = Array.from(grid?.children ?? [])
+      expect(children).toHaveLength(21)
+      expect(children[7]).toHaveAttribute('data-testid', 'mentors-list-ad')
+    })
+
+    it('places ad at position 8 with exactly 9 mentors', () => {
+      const { container } = render(
+        <MentorsList mentors={makeMentors(9)} hasMore={false} onClickMore={() => {}} showAd />
+      )
+
+      const grid = container.querySelector('.grid')
+      const children = Array.from(grid?.children ?? [])
+      expect(children).toHaveLength(10)
+      expect(children[7]).toHaveAttribute('data-testid', 'mentors-list-ad')
+    })
   })
 })

--- a/src/__tests__/components/MentorsListAd.test.tsx
+++ b/src/__tests__/components/MentorsListAd.test.tsx
@@ -1,0 +1,104 @@
+import { render, cleanup } from '@testing-library/react'
+import MentorsListAd from '@/components/mentors/MentorsListAd'
+
+interface RenderCall {
+  blockId: string
+  renderTo: string
+}
+
+declare global {
+  interface Window {
+    __yaRenderCalls?: RenderCall[]
+    __yaDestroyCalls?: RenderCall[]
+  }
+}
+
+function installFakeYa(): void {
+  window.__yaRenderCalls = []
+  window.__yaDestroyCalls = []
+  window.Ya = {
+    Context: {
+      AdvManager: {
+        render: (opts: RenderCall) => {
+          window.__yaRenderCalls?.push(opts)
+        },
+        destroy: (opts: RenderCall) => {
+          window.__yaDestroyCalls?.push(opts)
+        },
+      },
+    },
+  }
+  // Mimic Yandex's loader behavior: anything pushed to yaContextCb is
+  // executed immediately once the SDK is available.
+  const queue: Array<() => void> = []
+  window.yaContextCb = Object.assign(queue, {
+    push: (cb: () => void) => {
+      cb()
+      return queue.length
+    },
+  })
+}
+
+function uninstallFakeYa(): void {
+  delete window.Ya
+  delete window.yaContextCb
+  delete window.__yaRenderCalls
+  delete window.__yaDestroyCalls
+}
+
+describe('MentorsListAd', () => {
+  beforeEach(() => {
+    installFakeYa()
+  })
+
+  afterEach(() => {
+    cleanup()
+    uninstallFakeYa()
+  })
+
+  it('renders a slot with the configured id', () => {
+    const { container } = render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(container.querySelector('#my-slot')).not.toBeNull()
+  })
+
+  it('calls Ya render with the configured block id and slot id on mount', () => {
+    render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(window.__yaRenderCalls).toEqual([{ blockId: 'R-X-1', renderTo: 'my-slot' }])
+  })
+
+  it('calls Ya destroy on unmount', () => {
+    const { unmount } = render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(window.__yaDestroyCalls).toHaveLength(1) // destroy-then-render on mount
+    unmount()
+    expect(window.__yaDestroyCalls).toHaveLength(2)
+    expect(window.__yaDestroyCalls?.[1]).toEqual({ blockId: 'R-X-1', renderTo: 'my-slot' })
+  })
+
+  it('queues callbacks safely when Yandex SDK is not loaded yet', () => {
+    // Reset to a plain array (SDK has not arrived).
+    window.yaContextCb = []
+    delete window.Ya
+
+    const { unmount } = render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(window.yaContextCb).toHaveLength(1)
+
+    unmount()
+    expect(window.yaContextCb).toHaveLength(2)
+  })
+
+  it('re-runs render when re-mounted (simulating a filter change)', () => {
+    const { unmount } = render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(window.__yaRenderCalls).toHaveLength(1)
+    unmount()
+
+    render(<MentorsListAd id="my-slot" blockId="R-X-1" />)
+    expect(window.__yaRenderCalls).toHaveLength(2)
+  })
+
+  it('uses the default block id and slot id when not provided', () => {
+    render(<MentorsListAd />)
+    expect(window.__yaRenderCalls).toEqual([
+      { blockId: 'R-A-19309570-2', renderTo: 'mentors-list-ad-slot' },
+    ])
+  })
+})

--- a/src/__tests__/components/MentorsListAd.test.tsx
+++ b/src/__tests__/components/MentorsListAd.test.tsx
@@ -1,4 +1,4 @@
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, act, screen } from '@testing-library/react'
 import MentorsListAd from '@/components/mentors/MentorsListAd'
 
 interface RenderCall {
@@ -112,6 +112,101 @@ describe('MentorsListAd', () => {
     render(<MentorsListAd id="my-slot" />)
     expect(window.__yaRenderCalls).toEqual([])
     expect(window.__yaDestroyCalls).toEqual([])
+  })
+
+  describe('ad blocker fallback', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+      jest.useRealTimers()
+    })
+
+    it('does not show the fallback while Yandex SDK is available', () => {
+      render(<MentorsListAd id="my-slot" blockId="R-X-1" blockDetectionTimeoutMs={3000} />)
+      act(() => {
+        jest.advanceTimersByTime(3500)
+      })
+      expect(screen.queryByTestId('mentors-list-ad-fallback')).not.toBeInTheDocument()
+    })
+
+    it('shows the fallback message when the Yandex SDK fails to load', () => {
+      delete window.Ya
+      window.yaContextCb = []
+
+      render(<MentorsListAd id="my-slot" blockId="R-X-1" blockDetectionTimeoutMs={3000} />)
+      expect(screen.queryByTestId('mentors-list-ad-fallback')).not.toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(3500)
+      })
+
+      expect(screen.getByTestId('mentors-list-ad-fallback')).toBeInTheDocument()
+      expect(
+        screen.getByText('Здесь должен был быть рекламный блок, но его заблокировали')
+      ).toBeInTheDocument()
+    })
+
+    it('hides the fallback if the SDK loads later than the timeout', () => {
+      delete window.Ya
+      window.yaContextCb = []
+
+      render(<MentorsListAd id="my-slot" blockId="R-X-1" blockDetectionTimeoutMs={3000} />)
+      act(() => {
+        jest.advanceTimersByTime(3500)
+      })
+      expect(screen.getByTestId('mentors-list-ad-fallback')).toBeInTheDocument()
+
+      // Yandex SDK finally arrives and drains the queue.
+      const renderCalls: RenderCall[] = []
+      const destroyCalls: RenderCall[] = []
+      window.__yaRenderCalls = renderCalls
+      window.__yaDestroyCalls = destroyCalls
+      window.Ya = {
+        Context: {
+          AdvManager: {
+            render: (opts) => renderCalls.push(opts),
+            destroy: (opts) => destroyCalls.push(opts),
+          },
+        },
+      }
+      const queued = window.yaContextCb as Array<() => void>
+      act(() => {
+        queued.forEach((cb) => cb())
+      })
+
+      expect(screen.queryByTestId('mentors-list-ad-fallback')).not.toBeInTheDocument()
+      expect(renderCalls).toHaveLength(1)
+    })
+
+    it('does not show the fallback before the timeout elapses', () => {
+      delete window.Ya
+      window.yaContextCb = []
+
+      render(<MentorsListAd id="my-slot" blockId="R-X-1" blockDetectionTimeoutMs={3000} />)
+      act(() => {
+        jest.advanceTimersByTime(2000)
+      })
+      expect(screen.queryByTestId('mentors-list-ad-fallback')).not.toBeInTheDocument()
+    })
+
+    it('keeps the slot div in the DOM even when fallback is visible', () => {
+      delete window.Ya
+      window.yaContextCb = []
+
+      const { container } = render(
+        <MentorsListAd id="my-slot" blockId="R-X-1" blockDetectionTimeoutMs={3000} />
+      )
+      act(() => {
+        jest.advanceTimersByTime(3500)
+      })
+      // Slot must remain so a delayed SDK can still inject the iframe.
+      expect(container.querySelector('#my-slot')).not.toBeNull()
+    })
   })
 
   it('picks up a block id set after mount but before SDK loads', () => {

--- a/src/__tests__/components/MentorsListAd.test.tsx
+++ b/src/__tests__/components/MentorsListAd.test.tsx
@@ -44,6 +44,7 @@ function uninstallFakeYa(): void {
   delete window.yaContextCb
   delete window.__yaRenderCalls
   delete window.__yaDestroyCalls
+  delete window.getmentorAds
 }
 
 describe('MentorsListAd', () => {
@@ -95,10 +96,53 @@ describe('MentorsListAd', () => {
     expect(window.__yaRenderCalls).toHaveLength(2)
   })
 
-  it('uses the default block id and slot id when not provided', () => {
-    render(<MentorsListAd />)
-    expect(window.__yaRenderCalls).toEqual([
-      { blockId: 'R-A-19309570-2', renderTo: 'mentors-list-ad-slot' },
-    ])
+  it('reads block id from window.getmentorAds when no prop is passed', () => {
+    window.getmentorAds = { mentorsListBlockId: 'R-FROM-GTM-1' }
+    render(<MentorsListAd id="my-slot" />)
+    expect(window.__yaRenderCalls).toEqual([{ blockId: 'R-FROM-GTM-1', renderTo: 'my-slot' }])
+  })
+
+  it('prop blockId overrides window.getmentorAds', () => {
+    window.getmentorAds = { mentorsListBlockId: 'R-FROM-GTM-1' }
+    render(<MentorsListAd id="my-slot" blockId="R-PROP-1" />)
+    expect(window.__yaRenderCalls).toEqual([{ blockId: 'R-PROP-1', renderTo: 'my-slot' }])
+  })
+
+  it('does not call render when no block id is configured anywhere', () => {
+    render(<MentorsListAd id="my-slot" />)
+    expect(window.__yaRenderCalls).toEqual([])
+    expect(window.__yaDestroyCalls).toEqual([])
+  })
+
+  it('picks up a block id set after mount but before SDK loads', () => {
+    // Simulate GTM firing after React mount but before Yandex SDK is ready:
+    // start with a plain queue array, mount the component, then have GTM
+    // set the block id, then have the SDK consume the queue.
+    window.yaContextCb = []
+    delete window.Ya
+
+    render(<MentorsListAd id="my-slot" />)
+    expect(window.yaContextCb).toHaveLength(1)
+
+    // GTM fires — sets the block id.
+    window.getmentorAds = { mentorsListBlockId: 'R-LATE-1' }
+
+    // Yandex SDK loads — install Ya and drain the queue (as Yandex does).
+    const renderCalls: RenderCall[] = []
+    const destroyCalls: RenderCall[] = []
+    window.__yaRenderCalls = renderCalls
+    window.__yaDestroyCalls = destroyCalls
+    window.Ya = {
+      Context: {
+        AdvManager: {
+          render: (opts) => renderCalls.push(opts),
+          destroy: (opts) => destroyCalls.push(opts),
+        },
+      },
+    }
+    const queued = window.yaContextCb as Array<() => void>
+    queued.forEach((cb) => cb())
+
+    expect(renderCalls).toEqual([{ blockId: 'R-LATE-1', renderTo: 'my-slot' }])
   })
 })

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export { default as CalendlabWidget } from './calendar/CalendlabWidget'
 
 // Mentor Components
 export { default as MentorsList } from './mentors/MentorsList'
+export { default as MentorsListAd } from './mentors/MentorsListAd'
 export { default as MentorsFilters } from './mentors/MentorsFilters'
 export { default as MentorsSearch } from './mentors/MentorsSearch'
 export { default as FilterGroupDropdown } from './mentors/FilterGroupDropdown'

--- a/src/components/mentors/MentorsList.tsx
+++ b/src/components/mentors/MentorsList.tsx
@@ -1,65 +1,88 @@
+import { Fragment } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import pluralize from '@/lib/pluralize'
 import { imageLoader, updatedAtToVersion } from '@/lib/azure-image-loader'
+import MentorsListAd from './MentorsListAd'
 import type { MentorListItem } from '@/types'
 
 interface MentorsListProps {
   mentors: MentorListItem[]
   hasMore: boolean
   onClickMore: () => void
+  showAd?: boolean
+}
+
+function getAdPosition(mentorsCount: number): number | null {
+  if (mentorsCount < 4) return null
+  if (mentorsCount < 9) return 4
+  return 8
 }
 
 export default function MentorsList({
   mentors,
   hasMore,
   onClickMore,
+  showAd = false,
 }: MentorsListProps): JSX.Element {
+  const adPosition = showAd ? getAdPosition(mentors.length) : null
+
   return (
     <>
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mb-4">
-        {mentors.map((mentor) => (
-          <Link key={mentor.id} href={'/mentor/' + mentor.slug} target="_blank">
-            <div className="aspect-w-5 aspect-h-4 bg-center bg-cover bg-no-repeat">
-              <Image
-                src={imageLoader({ src: mentor.slug, quality: 'large', version: updatedAtToVersion(mentor.updatedAt) })}
-                alt={mentor.name}
-                placeholder="blur"
-                blurDataURL={imageLoader({ src: mentor.slug, quality: 'small', version: updatedAtToVersion(mentor.updatedAt) })}
-                fill
-                sizes="100vw"
-                style={{
-                  objectFit: 'cover',
-                }}
-                unoptimized
-              />
-              {mentor.isNew && (
-                <div className="bg-gray-800 text-white w-20 h-1 absolute m-2 rounded-lg p-1.5 h-8 align-middle text-center text-sm">
-                  🎉 New
-                </div>
-              )}
-            </div>
-
-            <div className="mt-3 mb-5">
-              <div className="text-2xl mb-1">{mentor.name}</div>
-              <div className="mb-2">
-                {mentor.job} @ {mentor.workplace}
+        {mentors.map((mentor, index) => (
+          <Fragment key={mentor.id}>
+            {adPosition !== null && index === adPosition - 1 && <MentorsListAd />}
+            <Link href={'/mentor/' + mentor.slug} target="_blank">
+              <div className="aspect-w-5 aspect-h-4 bg-center bg-cover bg-no-repeat">
+                <Image
+                  src={imageLoader({
+                    src: mentor.slug,
+                    quality: 'large',
+                    version: updatedAtToVersion(mentor.updatedAt),
+                  })}
+                  alt={mentor.name}
+                  placeholder="blur"
+                  blurDataURL={imageLoader({
+                    src: mentor.slug,
+                    quality: 'small',
+                    version: updatedAtToVersion(mentor.updatedAt),
+                  })}
+                  fill
+                  sizes="100vw"
+                  style={{
+                    objectFit: 'cover',
+                  }}
+                  unoptimized
+                />
+                {mentor.isNew && (
+                  <div className="bg-gray-800 text-white w-20 h-1 absolute m-2 rounded-lg p-1.5 h-8 align-middle text-center text-sm">
+                    🎉 New
+                  </div>
+                )}
               </div>
 
-              <div>😎 {mentor.experience} лет опыта</div>
-              <div>💰 {mentor.price}</div>
-              {mentor.menteeCount > 0 && (
-                <div>
-                  🤝 {mentor.menteeCount}{' '}
-                  {pluralize(mentor.menteeCount, [
-                    'человек получил помощь',
-                    'человека получили помощь',
-                    'человек получили помощь',
-                  ])}
+              <div className="mt-3 mb-5">
+                <div className="text-2xl mb-1">{mentor.name}</div>
+                <div className="mb-2">
+                  {mentor.job} @ {mentor.workplace}
                 </div>
-              )}
-            </div>
-          </Link>
+
+                <div>😎 {mentor.experience} лет опыта</div>
+                <div>💰 {mentor.price}</div>
+                {mentor.menteeCount > 0 && (
+                  <div>
+                    🤝 {mentor.menteeCount}{' '}
+                    {pluralize(mentor.menteeCount, [
+                      'человек получил помощь',
+                      'человека получили помощь',
+                      'человек получили помощь',
+                    ])}
+                  </div>
+                )}
+              </div>
+            </Link>
+          </Fragment>
         ))}
       </div>
 

--- a/src/components/mentors/MentorsListAd.tsx
+++ b/src/components/mentors/MentorsListAd.tsx
@@ -1,4 +1,6 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBan } from '@fortawesome/free-solid-svg-icons'
 
 type YaContextCallback = () => void
 
@@ -22,10 +24,12 @@ declare global {
 }
 
 const DEFAULT_SLOT_ID = 'mentors-list-ad-slot'
+const BLOCK_DETECTION_TIMEOUT_MS = 3000
 
 interface MentorsListAdProps {
   id?: string
   blockId?: string
+  blockDetectionTimeoutMs?: number
 }
 
 function queueYaCallback(cb: YaContextCallback): void {
@@ -43,9 +47,16 @@ function resolveBlockId(override?: string): string | undefined {
 export default function MentorsListAd({
   id = DEFAULT_SLOT_ID,
   blockId,
+  blockDetectionTimeoutMs = BLOCK_DETECTION_TIMEOUT_MS,
 }: MentorsListAdProps): JSX.Element {
+  const [isBlocked, setIsBlocked] = useState(false)
+
   useEffect(() => {
+    let cancelled = false
+
     queueYaCallback(() => {
+      if (cancelled) return
+      setIsBlocked(false)
       const resolvedBlockId = resolveBlockId(blockId)
       if (!resolvedBlockId) return
       const advManager = window.Ya?.Context?.AdvManager
@@ -58,7 +69,16 @@ export default function MentorsListAd({
       advManager.render({ blockId: resolvedBlockId, renderTo: id })
     })
 
+    const blockDetectionTimer = window.setTimeout(() => {
+      if (cancelled) return
+      if (!window.Ya?.Context?.AdvManager) {
+        setIsBlocked(true)
+      }
+    }, blockDetectionTimeoutMs)
+
     return () => {
+      cancelled = true
+      window.clearTimeout(blockDetectionTimer)
       queueYaCallback(() => {
         const resolvedBlockId = resolveBlockId(blockId)
         if (!resolvedBlockId) return
@@ -71,15 +91,26 @@ export default function MentorsListAd({
         }
       })
     }
-  }, [blockId, id])
+  }, [blockId, id, blockDetectionTimeoutMs])
 
   return (
     <div
       data-testid="mentors-list-ad"
       aria-label="Реклама"
-      className="w-full h-[480px] sm:h-[420px] overflow-hidden bg-gray-100"
+      className="relative w-full h-[480px] sm:h-[420px] overflow-hidden bg-gray-100"
     >
       <div id={id} className="w-full h-full overflow-hidden" />
+      {isBlocked && (
+        <div
+          data-testid="mentors-list-ad-fallback"
+          className="absolute inset-0 flex flex-col items-center justify-center bg-gray-100 text-gray-500 px-6 text-center"
+        >
+          <FontAwesomeIcon icon={faBan} size="2x" className="mb-3 text-gray-400" />
+          <p className="text-sm leading-relaxed">
+            Здесь должен был быть рекламный блок, но его заблокировали
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/mentors/MentorsListAd.tsx
+++ b/src/components/mentors/MentorsListAd.tsx
@@ -1,0 +1,17 @@
+interface MentorsListAdProps {
+  id?: string
+}
+
+export default function MentorsListAd({
+  id = 'mentors-list-ad-slot',
+}: MentorsListAdProps): JSX.Element {
+  return (
+    <div
+      data-testid="mentors-list-ad"
+      aria-label="Реклама"
+      className="w-full h-[480px] sm:h-[420px] overflow-hidden bg-gray-100"
+    >
+      <div id={id} className="w-full h-full overflow-hidden" />
+    </div>
+  )
+}

--- a/src/components/mentors/MentorsListAd.tsx
+++ b/src/components/mentors/MentorsListAd.tsx
@@ -15,10 +15,12 @@ declare global {
         AdvManager?: YaAdvManager
       }
     }
+    getmentorAds?: {
+      mentorsListBlockId?: string
+    }
   }
 }
 
-const DEFAULT_BLOCK_ID = 'R-A-19309570-2'
 const DEFAULT_SLOT_ID = 'mentors-list-ad-slot'
 
 interface MentorsListAdProps {
@@ -32,28 +34,38 @@ function queueYaCallback(cb: YaContextCallback): void {
   window.yaContextCb.push(cb)
 }
 
+function resolveBlockId(override?: string): string | undefined {
+  if (override) return override
+  if (typeof window === 'undefined') return undefined
+  return window.getmentorAds?.mentorsListBlockId
+}
+
 export default function MentorsListAd({
   id = DEFAULT_SLOT_ID,
-  blockId = DEFAULT_BLOCK_ID,
+  blockId,
 }: MentorsListAdProps): JSX.Element {
   useEffect(() => {
     queueYaCallback(() => {
+      const resolvedBlockId = resolveBlockId(blockId)
+      if (!resolvedBlockId) return
       const advManager = window.Ya?.Context?.AdvManager
       if (!advManager) return
       try {
-        advManager.destroy({ blockId, renderTo: id })
+        advManager.destroy({ blockId: resolvedBlockId, renderTo: id })
       } catch {
         // No existing block on first mount — expected.
       }
-      advManager.render({ blockId, renderTo: id })
+      advManager.render({ blockId: resolvedBlockId, renderTo: id })
     })
 
     return () => {
       queueYaCallback(() => {
+        const resolvedBlockId = resolveBlockId(blockId)
+        if (!resolvedBlockId) return
         const advManager = window.Ya?.Context?.AdvManager
         if (!advManager) return
         try {
-          advManager.destroy({ blockId, renderTo: id })
+          advManager.destroy({ blockId: resolvedBlockId, renderTo: id })
         } catch {
           // Already gone — ignore.
         }

--- a/src/components/mentors/MentorsListAd.tsx
+++ b/src/components/mentors/MentorsListAd.tsx
@@ -1,10 +1,66 @@
+import { useEffect } from 'react'
+
+type YaContextCallback = () => void
+
+interface YaAdvManager {
+  render: (options: { blockId: string; renderTo: string }) => void
+  destroy: (options: { blockId: string; renderTo: string }) => void
+}
+
+declare global {
+  interface Window {
+    yaContextCb?: Array<YaContextCallback>
+    Ya?: {
+      Context?: {
+        AdvManager?: YaAdvManager
+      }
+    }
+  }
+}
+
+const DEFAULT_BLOCK_ID = 'R-A-19309570-2'
+const DEFAULT_SLOT_ID = 'mentors-list-ad-slot'
+
 interface MentorsListAdProps {
   id?: string
+  blockId?: string
+}
+
+function queueYaCallback(cb: YaContextCallback): void {
+  if (typeof window === 'undefined') return
+  window.yaContextCb = window.yaContextCb ?? []
+  window.yaContextCb.push(cb)
 }
 
 export default function MentorsListAd({
-  id = 'mentors-list-ad-slot',
+  id = DEFAULT_SLOT_ID,
+  blockId = DEFAULT_BLOCK_ID,
 }: MentorsListAdProps): JSX.Element {
+  useEffect(() => {
+    queueYaCallback(() => {
+      const advManager = window.Ya?.Context?.AdvManager
+      if (!advManager) return
+      try {
+        advManager.destroy({ blockId, renderTo: id })
+      } catch {
+        // No existing block on first mount — expected.
+      }
+      advManager.render({ blockId, renderTo: id })
+    })
+
+    return () => {
+      queueYaCallback(() => {
+        const advManager = window.Ya?.Context?.AdvManager
+        if (!advManager) return
+        try {
+          advManager.destroy({ blockId, renderTo: id })
+        } catch {
+          // Already gone — ignore.
+        }
+      })
+    }
+  }, [blockId, id])
+
   return (
     <div
       data-testid="mentors-list-ad"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -208,6 +208,7 @@ export default function Home({
           mentors={mentors}
           hasMore={hasMoreMentors}
           onClickMore={handleShowMoreMentors}
+          showAd
         />
       </Section>
 

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -33,6 +33,7 @@ export interface MentorsListProps {
   mentors: MentorListItem[]
   hasMore: boolean
   onClickMore: () => void
+  showAd?: boolean
 }
 
 /**


### PR DESCRIPTION
Injects a fixed-size empty container into the mentors grid so an ad
platform can render into it. Position is 8 (1-indexed) when the
filtered list has 9+ mentors, 4 when it has 4-8, and the slot is
hidden below 4. Opt-in via the new showAd prop; only the homepage
enables it.

Also adds updatedAtToVersion to the azure-image-loader test mock so
MentorsList tests can run.